### PR TITLE
typo

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,7 +81,7 @@ app.get('/', function (req, res, next) {
 				SIGNATURE.signature = signature;
 				res.json({
 					signature: signature,
-					noncestr: SIGNATURE.noncestr,
+					nonceStr: SIGNATURE.noncestr,
 					timestamp: SIGNATURE.timestamp
 				})
 			})


### PR DESCRIPTION
返回数据中 `nonceStr` 最好是驼峰，因为前端使用时是驼峰格式（坑），后端才是全小写